### PR TITLE
Sync private contributor

### DIFF
--- a/src/Content/LeagueSandbox-Scripts/AIScripts/BasicJungleMonsterAI.cs
+++ b/src/Content/LeagueSandbox-Scripts/AIScripts/BasicJungleMonsterAI.cs
@@ -17,6 +17,7 @@ namespace AIScripts
         Vector2 initialPosition;
         Vector3 initialFacingDirection;
         bool isInCombat = false;
+        const float MAXIMUM_CHASE_RANGE = 1200f * 1200f;
         public void OnActivate(ObjAIBase owner)
         {
             monster = owner as Monster;
@@ -42,7 +43,7 @@ namespace AIScripts
                 if (isInCombat)
                 {
                     //Find a better way to do this
-                    if (Vector2.DistanceSquared(new Vector2(monster.Camp.Position.X, monster.Camp.Position.Z), monster.Position) > 800f * 800f)
+                    if (Vector2.DistanceSquared(new Vector2(monster.Camp.Position.X, monster.Camp.Position.Z), monster.Position) > MAXIMUM_CHASE_RANGE)
                     {
                         ResetCamp();
                     }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Ashe/CharScriptAshe.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Ashe/CharScriptAshe.cs
@@ -12,7 +12,7 @@ namespace CharScripts
         float Damage;
         float QDamage;
         Spell Passive;
-        ObjAIBase Ashe;
+        Champion Ashe;
         float Ampdamage;
         public void OnActivate(ObjAIBase owner, Spell spell = null)
         {
@@ -35,6 +35,10 @@ namespace CharScripts
                 {
                     damageData.Target.TakeDamage(Ashe, QDamage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
                 }
+            }
+            if (Ashe.Spells[2]?.CastInfo?.SpellLevel >= 1 && (damageData.Target?.IsDead ?? false))
+            {
+                Ashe.AddGold(damageData.Target, 3);
             }
         }
     }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Dragon/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Dragon/BasicAttack.cs
@@ -3,8 +3,18 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
-    public class DragonBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
+    public class DragonBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
@@ -48,7 +48,8 @@ namespace Spells
 
                 if (target.IsDead)
                 {
-                    owner.Stats.Gold += goldIncome;
+                    if (owner is Champion champ)
+                        champ.AddGold(target, goldIncome);
                     var manaCost = new float[] { 50, 55, 60, 65, 70 }[spell.CastInfo.SpellLevel - 1];
                     var newMana = owner.Stats.CurrentMana + manaCost / 2;
                     var maxMana = owner.Stats.ManaPoints.Total;

--- a/src/Content/LeagueSandbox-Scripts/Characters/Katarina/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Katarina/Q.cs
@@ -9,6 +9,7 @@ using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using static LeaguePackets.Game.Common.CastInfo;
 
 namespace Spells
 {
@@ -29,18 +30,41 @@ namespace Spells
         {
             QMis = spell;
             Katarina = spell.CastInfo.Owner as Champion;
-            Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Target });
+            Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Chained, MaximumHits=4 });
             ApiEventManager.OnSpellMissileHit.AddListener(this, Missile, TargetExecute, false);
         }
         public void TargetExecute(SpellMissile missile, AttackableUnit target)
         {
+            if (Target == null)
+                Target = target;
+
             Damage = 45f + (QMis.CastInfo.SpellLevel * 35f) + (Katarina.Stats.AbilityPower.Total * 0.5f);
             target.TakeDamage(Katarina, Damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             //AddParticleTarget(owner, target, "katarina_bouncingBlades_tar.troy", target);
+
+            var xx = GetClosestUnitsInRange(target, 300, true);
+            var targetsHit = 0;
+            foreach (var unit in xx)
+            {
+                if (unit.NetId != Katarina.NetId && !unit.IsDead && unit.Team != Katarina.Team
+                    && unit is not BaseTurret && unit.NetId != target.NetId 
+                    && !unit.HasBuff("KatarinaQMark"))
+                {
+                    LogInfo($"Hitting Second Target {unit.CharData.Name} - {unit.NetId}");
+                    SpellCast(Katarina, 2, SpellSlotType.ExtraSlots, false, unit, target.Position);
+                    break;
+                    Damage = Damage * 0.9f;
+                    unit.TakeDamage(Katarina, Damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+                    AddBuff("KatarinaQMark", 4f, 1, QMis, unit, Katarina, false);
+                    targetsHit++;
+                }
+                if (targetsHit >= 4)
+                    break;
+            }
+
             AddBuff("KatarinaQMark", 4f, 1, QMis, target, Katarina, false);
-            var xx = GetClosestUnitInRange(target, 300, true);
-            if (xx != Katarina && !xx.IsDead && xx != null) SpellCast(Katarina, 2, SpellSlotType.ExtraSlots, false, xx, target.Position);
         }
+
     }
     public class KatarinaQMis : ISpellScript
     {

--- a/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/E.cs
@@ -41,6 +41,8 @@ namespace Spells
         public void OnSpellPostCast(Spell spell)
         {
             Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Circle, });
+            if (!Leblanc.HasBuff("LeblancSlideM"))
+                Leblanc.SetSpell("LeblancSoulShackleM", 3, true);
         }
         public void TargetExecute(Spell spell, AttackableUnit target, SpellMissile missile, SpellSector sector)
         {

--- a/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/Q.cs
@@ -29,12 +29,15 @@ namespace Spells
 
         public void OnActivate(ObjAIBase owner, Spell spell)
         {
+
             Leblanc = owner = spell.CastInfo.Owner as Champion;
             ApiEventManager.OnSpellHit.AddListener(this, spell, TargetExecute, false);
         }
         public void OnSpellPostCast(Spell spell)
         {
             Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Target, });
+            if (!Leblanc.HasBuff("LeblancSlideM"))
+                Leblanc.SetSpell("LeblancChaosOrbM", 3, true);
         }
         public void TargetExecute(Spell spell, AttackableUnit target, SpellMissile missile, SpellSector sector)
         {

--- a/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/R.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/R.cs
@@ -15,34 +15,11 @@ namespace Spells
 {
     public class LeblancMimic : ISpellScript
     {
-        ObjAIBase Leblanc;
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
             TriggersSpellCasts = true,
             IsDamagingSpell = true
         };
-        public void OnActivate(ObjAIBase owner, Spell spell)
-        {
-            Leblanc = owner = spell.CastInfo.Owner as Champion;
-            ApiEventManager.OnLevelUpSpell.AddListener(this, spell, OnLevelUp, true);
-        }
-        public void OnLevelUp(Spell spell)
-        {
-            ApiEventManager.OnSpellCast.AddListener(this, Leblanc.Spells[0], ChangSpell0, false);
-            ApiEventManager.OnSpellCast.AddListener(this, Leblanc.GetSpell("LeblancSlide"), ChangSpell1, false);
-            ApiEventManager.OnSpellCast.AddListener(this, Leblanc.Spells[2], ChangSpell2, false);
-        }
-        public void ChangSpell0(Spell spell)
-        {
-            if (!Leblanc.HasBuff("LeblancSlideM")) { Leblanc.SetSpell("LeblancChaosOrbM", 3, true); }
-        }
-        public void ChangSpell1(Spell spell)
-        {
-            if (!Leblanc.HasBuff("LeblancSlideM")) { Leblanc.SetSpell("LeblancSlideM", 3, true); }
-        }
-        public void ChangSpell2(Spell spell)
-        {
-            if (!Leblanc.HasBuff("LeblancSlideM")) { Leblanc.SetSpell("LeblancSoulShackleM", 3, true); }
-        }
+        
     }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/W.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/LeBlanc/W.cs
@@ -56,7 +56,12 @@ namespace Spells
             POS = AddMinion(Leblanc, "TestCube", "TestCube", Leblanc.Position, Leblanc.Team, Leblanc.SkinID, true, false);
             AddBuff("LeblancSlideReturn", 4.0f, 1, spell, POS, Leblanc);
         }
-        public void OnSpellPostCast(Spell spell) { spell.SetCooldown(0.5f, true); }
+        public void OnSpellPostCast(Spell spell)
+        {
+            spell.SetCooldown(0.5f, true);
+            if (!Leblanc.HasBuff("LeblancSlideM"))
+                Leblanc.SetSpell("LeblancSlideM", 3, true);
+        }
         public void OnMoveEnd(AttackableUnit owner)
         {
             SetStatus(Leblanc, StatusFlags.Ghosted, false);

--- a/src/Content/LeagueSandbox-Scripts/Characters/Minions/CannonMinion.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Minions/CannonMinion.cs
@@ -3,11 +3,48 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
-    public class Blue_Minion_MechCannonBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Blue_Minion_MechCannonBasicAttack2 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Red_Minion_MechCannonBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Red_Minion_MechCannonBasicAttack2 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
+    public class Blue_Minion_MechCannonBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+    public class Blue_Minion_MechCannonBasicAttack2 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+    public class Red_Minion_MechCannonBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+    public class Red_Minion_MechCannonBasicAttack2 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Minions/WizardMinion.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Minions/WizardMinion.cs
@@ -3,11 +3,53 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Enums;
+using LeagueSandbox.GameServer.API;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
+using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
+using System;
 
 namespace Spells
 {
-    public class Blue_Minion_WizardBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Blue_Minion_WizardBasicAttack2 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Red_Minion_WizardBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class Red_Minion_WizardBasicAttack2 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
+    public class Blue_Minion_WizardBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+    }
+    public class Blue_Minion_WizardBasicAttack2 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+    public class Red_Minion_WizardBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+    public class Red_Minion_WizardBasicAttack2 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+    }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Worm/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Worm/BasicAttack.cs
@@ -1,0 +1,20 @@
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Enums;
+
+namespace Spells
+{
+    public class WormBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Characters/YoungLizard/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/YoungLizard/BasicAttack.cs
@@ -3,10 +3,40 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using GameServerCore.Enums;
 
 namespace Spells
 {
-    public class YoungLizardBasicAttack : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class YoungLizardBasicAttack2 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
-    public class YoungLizardBasicAttack3 : ISpellScript { public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata(); public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { } }
+    public class YoungLizardBasicAttack : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+
+    public class YoungLizardBasicAttack2 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
+
+    public class YoungLizardBasicAttack3 : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true,
+            MissileParameters = new MissileParameters { Type = MissileType.Target }
+        };
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
+    }
 }

--- a/src/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
+++ b/src/Content/LeagueSandbox-Scripts/Maps/Map1/URFMutator.cs
@@ -18,7 +18,7 @@ namespace MapScripts.Map1
         {
             base.Init(mapObjects);
             SetGameFeatures(FeatureFlags.EnableManaCosts, false);
-            GlobalData.GlobalCharacterDataConstants.PercentCooldownModMinimum = -0.8f;
+            //GlobalData.GlobalCharacterDataConstants.PercentCooldownModMinimum = -0.8f;
         }
 
         public override void OnMatchStart()
@@ -28,6 +28,7 @@ namespace MapScripts.Map1
             {
                 //There are mentions to a "rewindcof" buff being loaded too, but it's functions are yet unknown
                 AddBuff("InternalTestBuff", float.MaxValue, 1, null, player, null, true);
+                player.Stats.CooldownReduction.PercentBaseBonus += 0.8f;
             }
         }
     }

--- a/src/GameServerLib/Config.cs
+++ b/src/GameServerLib/Config.cs
@@ -28,6 +28,7 @@ namespace LeagueSandbox.GameServer
         public FeatureFlags GameFeatures { get; private set; }
         public const string VERSION_STRING = "Version 4.20.0.315 [PUBLIC]";
         public static readonly Version VERSION = new Version(4, 20, 0, 315);
+        internal string[] AssemblyNames { get; private set; } = [];
 
         public bool ChatCheatsEnabled { get; private set; }
         public string ContentPath { get; private set; }
@@ -95,6 +96,7 @@ namespace LeagueSandbox.GameServer
             }
 
             ForcedStart = (float)(data.SelectToken("forcedStart") ?? 0) * 1000;
+            AssemblyNames = gameInfo?.SelectToken("scriptAssemblies")?.Values<string>().ToArray() as string[] ?? [];
         }
 
         public void LoadContent(Game game)

--- a/src/GameServerLib/Content/CharData.cs
+++ b/src/GameServerLib/Content/CharData.cs
@@ -17,6 +17,7 @@ namespace LeagueSandbox.GameServer.Content
 
     public class CharData
     {
+        public string Name { get; private set; }
         public float AcquisitionRange { get; private set; } = 475;
         public bool AllyCanUse { get; private set; } = false;
         public bool AlwaysVisible { get; private set; } = false;
@@ -91,7 +92,7 @@ namespace LeagueSandbox.GameServer.Content
         public CharData Load(ContentFile file)
         {
             string name = file.Name;
-
+            Name = name;
             AcquisitionRange = file.GetFloat("Data", "AcquisitionRange", AcquisitionRange);
             Armor = file.GetFloat("Data", "Armor", Armor);
             ArmorPerLevel = file.GetFloat("Data", "ArmorPerLevel", ArmorPerLevel);

--- a/src/GameServerLib/Content/Package.cs
+++ b/src/GameServerLib/Content/Package.cs
@@ -315,7 +315,7 @@ namespace LeagueSandbox.GameServer.Content
 
         public bool LoadScripts()
         {
-            var scriptLoadResult = _game.ScriptEngine.LoadSubDirectoryScripts(PackagePath);
+            var scriptLoadResult = Game.ScriptEngine.LoadSubDirectoryScripts(PackagePath);
             switch (scriptLoadResult)
             {
                 case CompilationStatus.Compiled:

--- a/src/GameServerLib/Game.cs
+++ b/src/GameServerLib/Game.cs
@@ -22,6 +22,7 @@ using GameServerCore.Packets.PacketDefinitions;
 using GameServerCore.Packets.PacketDefinitions.Requests;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using GameServerLib.Handlers;
+using GameServerLib.Scripting;
 
 namespace LeagueSandbox.GameServer
 {
@@ -36,7 +37,7 @@ namespace LeagueSandbox.GameServer
 
         // Function Vars
         private static ILog _logger = LoggerProvider.GetLogger();
-        private float _nextSyncTime = 10 * 1000;
+        private float _nextSyncTime = 5 * 1000;
         protected const double REFRESH_RATE = 1000.0 / 60.0; // GameLoop called 60 times a second.
         private HandleStartGame _gameStartHandler;
 
@@ -65,6 +66,12 @@ namespace LeagueSandbox.GameServer
         /// Time since the game has started. Mostly used for networking to sync up players with the server.
         /// </summary>
         public float GameTime { get; private set; }
+
+        /// <summary>
+        /// Last Frame DeltaTime
+        /// </summary>
+        public float FrameDelta { get; private set; }
+
         /// <summary>
         /// Handler for request packets sent by game clients.
         /// </summary>
@@ -116,7 +123,7 @@ namespace LeagueSandbox.GameServer
         /// <summary>
         /// Class that compiles and loads all scripts which will be used for the game (ex: spells, items, AI, maps, etc).
         /// </summary>
-        internal CSharpScriptEngine ScriptEngine { get; private set; }
+        internal static CSharpScriptEngine ScriptEngine { get; private set; }
 
         internal FileSystemWatcher ScriptsHotReloadWatcher { get; private set; }
 
@@ -144,6 +151,7 @@ namespace LeagueSandbox.GameServer
             _logger.Info("Loading Config.");
             Config = config;
             Config.LoadContent(this);
+            AssemblyService.TryLoadAssemblies(Config.AssemblyNames);
             _gameScriptTimers = new List<GameScriptTimer>();
 
             ChatCommandManager.LoadCommands();
@@ -327,6 +335,8 @@ namespace LeagueSandbox.GameServer
                 lastMapDurationWatch.Restart();
 
                 float deltaTime = (float)lastSleepDuration;
+                FrameDelta = deltaTime;
+
                 if (firstCycle)
                 {
                     firstCycle = false;
@@ -381,7 +391,6 @@ namespace LeagueSandbox.GameServer
                         Update(deltaTime);
                     }
                 }
-
                 double lastUpdateDuration = lastMapDurationWatch.Elapsed.TotalMilliseconds;
                 double oversleep = lastSleepDuration - timeout;
                 timeout = Math.Max(0, refreshRate - lastUpdateDuration - oversleep);
@@ -401,7 +410,11 @@ namespace LeagueSandbox.GameServer
             // Collision
             Map.Update(diff);
             // Objects
+            var watch = Stopwatch.StartNew();
             ObjectManager.Update(diff);
+            watch.Stop();
+            //if (watch.Elapsed.TotalMilliseconds > 5)
+            //    _logger.Info($"Object Manager Update took {watch.Elapsed.TotalMilliseconds}ms");
             // Protection (TODO: Move this into ObjectManager).
             ProtectionManager.Update(diff);
             ChatCommandManager.GetCommands().ForEach(command => command.Update(diff));

--- a/src/GameServerLib/Game.cs
+++ b/src/GameServerLib/Game.cs
@@ -37,8 +37,8 @@ namespace LeagueSandbox.GameServer
 
         // Function Vars
         private static ILog _logger = LoggerProvider.GetLogger();
-        private float _nextSyncTime = 5 * 1000;
-        protected const double REFRESH_RATE = 1000.0 / 60.0; // GameLoop called 60 times a second.
+        private float _nextSyncTime = 10 * 1000;
+        protected const double REFRESH_RATE = 1000.0 / /*60.0*/ 30.0f; // GameLoop called 60 times a second.
         private HandleStartGame _gameStartHandler;
 
         // Server

--- a/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -14,6 +14,7 @@ using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using log4net;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
 using LeagueSandbox.GameServer.GameObjects.StatsNS;
+using LeagueSandbox.GameServer.Handlers;
 
 namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 {
@@ -227,7 +228,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 IsMelee = true;
             }
 
-            AIScript = game.ScriptEngine.CreateObject<IAIScript>($"AIScripts", aiScript) ?? new EmptyAIScript();
+            AIScript = Game.ScriptEngine.CreateObject<IAIScript>($"AIScripts", aiScript) ?? new EmptyAIScript();
             try
             {
                 AIScript.OnActivate(this);
@@ -260,7 +261,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         /// </summary>
         public void LoadCharScript(Spell spell = null)
         {
-            CharScript = CSharpScriptEngine.CreateObjectStatic<ICharScript>("CharScripts", $"CharScript{Model}") ?? new CharScriptEmpty();
+            CharScript = Game.ScriptEngine.CreateObject<ICharScript>("CharScripts", $"CharScript{Model}") ?? new CharScriptEmpty();
         }
 
         /// <summary>
@@ -556,7 +557,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
         public bool RecalculateAttackPosition()
         {
             // If we are already where we should be, which means we are in attack range, then keep our current position.
-            if (TargetUnit == null || TargetUnit.IsDead || Vector2.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
+            if (TargetUnit == null || TargetUnit.IsDead || CollisionHandler.DistanceSquared(Position, TargetUnit.Position) <= Stats.Range.Total * Stats.Range.Total)
             {
                 return false;
             }
@@ -569,7 +570,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 if (unit == null ||
                     unit.NetId == NetId ||
                     unit.IsDead ||
-                    Vector2.DistanceSquared(Position, TargetUnit.Position) > DETECT_RANGE * DETECT_RANGE
+                    CollisionHandler.DistanceSquared(Position, TargetUnit.Position) > DETECT_RANGE * DETECT_RANGE
                 )
                 {
                     continue;
@@ -637,7 +638,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             if (MoveOrder == OrderType.AttackMove
                 && targetPos != Vector2.Zero
                 && MovementParameters == null
-                && Vector2.DistanceSquared(Position, targetPos) <= idealRange * idealRange
+                && CollisionHandler.DistanceSquared(Position, targetPos) <= idealRange * idealRange
                 && _autoAttackCurrentCooldown <= 0)
             {
                 UpdateMoveOrder(OrderType.Stop, true);
@@ -650,7 +651,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
             if (MoveOrder == OrderType.AttackTo && targetPos != Vector2.Zero)
             {
-                if (Vector2.DistanceSquared(Position, targetPos) <= idealRange * idealRange)
+                if (CollisionHandler.DistanceSquared(Position, targetPos) <= idealRange * idealRange)
                 {
                     UpdateMoveOrder(OrderType.Hold, true);
                 }
@@ -1141,8 +1142,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                         && !u.IsDead
                         && u.Team == Team
                         && u.AIScript.AIScriptMetaData.HandlesCallsForHelp
-                        && Vector2.DistanceSquared(u.Position, Position) <= acquisitionRangeSquared
-                        && Vector2.DistanceSquared(u.Position, attacker.Position) <= acquisitionRangeSquared
+                        && CollisionHandler.DistanceSquared(u.Position, Position) <= acquisitionRangeSquared
+                        && CollisionHandler.DistanceSquared(u.Position, attacker.Position) <= acquisitionRangeSquared
                     )
                     {
                         try
@@ -1213,12 +1214,12 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
                 if (MoveOrder == OrderType.AttackTo
                     && TargetUnit != null
-                    && Vector2.DistanceSquared(TargetUnit.Position, SpellToCast.CastInfo.Owner.Position) <= idealRange * idealRange)
+                    && CollisionHandler.DistanceSquared(TargetUnit.Position, SpellToCast.CastInfo.Owner.Position) <= idealRange * idealRange)
                 {
                     SpellToCast.Cast(new Vector2(SpellToCast.CastInfo.TargetPosition.X, SpellToCast.CastInfo.TargetPosition.Z), new Vector2(SpellToCast.CastInfo.TargetPositionEnd.X, SpellToCast.CastInfo.TargetPositionEnd.Z), TargetUnit);
                 }
                 else if (MoveOrder == OrderType.MoveTo
-                        && Vector2.DistanceSquared(new Vector2(SpellToCast.CastInfo.TargetPosition.X, SpellToCast.CastInfo.TargetPosition.Z), SpellToCast.CastInfo.Owner.Position) <= idealRange * idealRange)
+                        && CollisionHandler.DistanceSquared(new Vector2(SpellToCast.CastInfo.TargetPosition.X, SpellToCast.CastInfo.TargetPosition.Z), SpellToCast.CastInfo.Owner.Position) <= idealRange * idealRange)
                 {
                     SpellToCast.Cast(new Vector2(SpellToCast.CastInfo.TargetPosition.X, SpellToCast.CastInfo.TargetPosition.Z), new Vector2(SpellToCast.CastInfo.TargetPositionEnd.X, SpellToCast.CastInfo.TargetPositionEnd.Z));
                 }
@@ -1234,7 +1235,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                 {
                     idealRange = Stats.Range.Total + TargetUnit.CollisionRadius;
 
-                    if (Vector2.DistanceSquared(Position, TargetUnit.Position) <= idealRange * idealRange && MovementParameters == null)
+                    if (CollisionHandler.DistanceSquared(Position, TargetUnit.Position) <= idealRange * idealRange && MovementParameters == null)
                     {
                         if (AutoAttackSpell.State == SpellState.STATE_READY)
                         {
@@ -1243,6 +1244,10 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
                             if (CanAttack())
                             {
+                                if (this.CharData.Name.Contains("Wizard"))
+                                {
+                                    //_logger.Info($"Minion {CharData.Name}: AA {AutoAttackSpell.SpellName} - {AutoAttackSpell.Script?.GetType()?.Name}");
+                                }
                                 IsNextAutoCrit = _random.Next(0, 100) < Stats.CriticalChance.Total * 100;
                                 if (_autoAttackCurrentCooldown <= 0)
                                 {
@@ -1303,18 +1308,18 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                             if (!(it.Value is AttackableUnit u) ||
                                 u.IsDead ||
                                 u.Team == Team ||
-                                Vector2.DistanceSquared(Position, u.Position) > range * range ||
+                                CollisionHandler.DistanceSquared(Position, u.Position) > range * range ||
                                 !u.Status.HasFlag(StatusFlags.Targetable))
                             {
                                 continue;
                             }
 
-                            if (!(Vector2.DistanceSquared(Position, u.Position) < distanceSqrToTarget))
+                            if (!(CollisionHandler.DistanceSquared(Position, u.Position) < distanceSqrToTarget))
                             {
                                 continue;
                             }
 
-                            distanceSqrToTarget = Vector2.DistanceSquared(Position, u.Position);
+                            distanceSqrToTarget = CollisionHandler.DistanceSquared(Position, u.Position);
                             nextTarget = u;
                         }
 

--- a/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -367,7 +367,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
 
         public bool CanLevelUpSpell(Spell s)
         {
-            return CharData.SpellsUpLevels[s.CastInfo.SpellSlot][s.CastInfo.SpellLevel] <= Stats.Level;
+            return CharData.SpellsUpLevels[s.CastInfo.OgSpellSlot != 255 ? s.CastInfo.OgSpellSlot : s.CastInfo.SpellSlot][s.CastInfo.SpellLevel] <= Stats.Level;
         }
 
         public virtual bool LevelUp(bool force = true)
@@ -861,6 +861,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
                     toReturn.Script.OnActivate(this, toReturn);
                 }
 
+                toReturn.CastInfo.OgSpellSlot = slot;
                 Spells[slot] = toReturn;
                 Stats.SetSpellEnabled(slot, enabled);
             }

--- a/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1367,6 +1367,16 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         }
 
         /// <summary>
+        /// Gets a list of all buff names.
+        /// </summary>
+        /// <param name="buffName">Internal buff name to check.</param>
+        /// <returns>List of buff instances.</returns>
+        public string GetBuffNames()
+        {
+            return string.Join(",", BuffList.Select(b => b.Name));
+        }
+
+        /// <summary>
         /// Removes the given buff from this unit. Called automatically when buff timers have finished.
         /// Buffs with BuffAddType.STACKS_AND_OVERLAPS are removed incrementally, meaning one instance removed per RemoveBuff call.
         /// Other BuffAddTypes are removed entirely, regardless of stacks. DecrementStackCount can be used as an alternative.

--- a/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -17,6 +17,7 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
 {
@@ -585,6 +586,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             Stats.CurrentHealth = Math.Max(0.0f, Stats.CurrentHealth - damageData.PostMitigationDamage);
 
             ApiEventManager.OnTakeDamage.Publish(damageData.Target, damageData);
+            ApiEventManager.OnDealDamage.Publish(damageData.Attacker, damageData);
 
             if (!IsDead && Stats.CurrentHealth <= 0)
             {

--- a/src/GameServerLib/GameObjects/Buff.cs
+++ b/src/GameServerLib/GameObjects/Buff.cs
@@ -111,7 +111,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         public void LoadScript()
         {
             ApiEventManager.RemoveAllListenersForOwner(BuffScript);
-            BuffScript = CSharpScriptEngine.CreateObjectStatic<IBuffGameScript>("Buffs", Name) ?? new BuffScriptEmpty();
+            BuffScript = Game.ScriptEngine.CreateObject<IBuffGameScript>("Buffs", Name) ?? new BuffScriptEmpty();
         }
 
         public void ActivateBuff()

--- a/src/GameServerLib/GameObjects/GameObject.cs
+++ b/src/GameServerLib/GameObjects/GameObject.cs
@@ -33,9 +33,9 @@ namespace LeagueSandbox.GameServer.GameObjects
         {
             get
             {
-                foreach(var kv in _visibleForPlayers)
+                foreach (var kv in _visibleForPlayers)
                 {
-                    if(kv.Value)
+                    if (kv.Value)
                     {
                         yield return kv.Key;
                     }
@@ -271,7 +271,7 @@ namespace LeagueSandbox.GameServer.GameObjects
             {
                 if (IsAffectedByFoW && (IsVisibleForPlayer(userId) != visible))
                 {
-                    if(visible)
+                    if (visible)
                     {
                         OnEnterVision(userId, team);
                     }
@@ -281,7 +281,7 @@ namespace LeagueSandbox.GameServer.GameObjects
                     }
                     SetVisibleForPlayer(userId, visible);
                 }
-                else if(visible)
+                else if (visible)
                 {
                     OnSync(userId, team);
                 }
@@ -300,7 +300,7 @@ namespace LeagueSandbox.GameServer.GameObjects
 
         public virtual void OnReconnect(int userId, TeamId team)
         {
-            if(IsSpawnedForPlayer(userId))
+            if (IsSpawnedForPlayer(userId))
             {
                 Sync(userId, team, IsVisibleForPlayer(userId), true);
             }
@@ -347,7 +347,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         public List<TeamId> TeamsWithVision()
         {
             List<TeamId> toReturn = new List<TeamId>();
-            foreach(var team in _visibleByTeam.Keys)
+            foreach (var team in _visibleByTeam.Keys)
             {
                 if (_visibleByTeam[team])
                 {
@@ -446,5 +446,8 @@ namespace LeagueSandbox.GameServer.GameObjects
         {
             _game.PacketNotifier.NotifyS2C_StopAnimation(this, animation, stopAll, fade, ignoreLock);
         }
+
+        // Utility function
+        public Game GetGame() { return _game; }
     }
 }

--- a/src/GameServerLib/GameObjects/Spell/CastInfo.cs
+++ b/src/GameServerLib/GameObjects/Spell/CastInfo.cs
@@ -35,6 +35,10 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
         public bool IsClickCasted { get; set; } = false;
 
         public byte SpellSlot { get; set; }
+        /// <summary>
+        /// Hack for Leblanc's Mimic (R)
+        /// </summary>
+        public byte OgSpellSlot { get; set; } = 255;
         public float ManaCost { get; set; }
         public Vector3 SpellCastLaunchPosition { get; set; }
         public int AmmoUsed { get; set; }

--- a/src/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
+++ b/src/GameServerLib/GameObjects/Spell/Missile/SpellMissile.cs
@@ -55,9 +55,13 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS.Missile
             CastInfo = castInfo;
 
             // TODO: Implement full support for multiple targets.
-            if (castInfo.Targets[0].Unit != null)
+            if (castInfo.Targets.Count > 0 && castInfo.Targets[0].Unit != null)
             {
                 TargetUnit = castInfo.Targets[0].Unit;
+            }
+            else
+            {
+                TargetUnit = null;
             }
 
             VisionRadius = SpellOrigin.SpellData.MissilePerceptionBubbleRadius;

--- a/src/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/src/GameServerLib/GameObjects/Spell/Spell.cs
@@ -870,7 +870,7 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
                 return;
             }
 
-            if (CastInfo.Targets[0].Unit != null)
+            if (CastInfo.Targets.Count > 0 && CastInfo.Targets[0].Unit != null)
             {
                 var spellTarget = CastInfo.Targets[0].Unit;
 

--- a/src/GameServerLib/GameObjects/Spell/Spell.cs
+++ b/src/GameServerLib/GameObjects/Spell/Spell.cs
@@ -146,7 +146,7 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
             {
                 nameSpace = "ItemSpells";
             }
-            Script = CSharpScriptEngine.CreateObjectStatic<ISpellScript>(nameSpace, SpellName) ?? new SpellScriptEmpty();
+            Script = Game.ScriptEngine.CreateObject<ISpellScript>(nameSpace, SpellName) ?? new SpellScriptEmpty();
 
             if (Script.ScriptMetadata.TriggersSpellCasts)
             {
@@ -875,9 +875,6 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
                 var spellTarget = CastInfo.Targets[0].Unit;
 
                 if (spellTarget != null && (!spellTarget.IsVisibleByTeam(CastInfo.Owner.Team) || (!spellTarget.Status.HasFlag(StatusFlags.Targetable) && !spellTarget.CharData.IsUseable) || spellTarget.IsDead))
-
-
-
                 {
                     CastInfo.Owner.StopChanneling(ChannelingStopCondition.Cancel, ChannelingStopSource.LostTarget);
                     return;
@@ -1372,7 +1369,7 @@ namespace LeagueSandbox.GameServer.GameObjects.SpellNS
 
         public void LowerCooldown(float lowerValue)
         {
-            SetCooldown(CurrentCooldown - lowerValue);
+            SetCooldown(CurrentCooldown - lowerValue, true);
         }
 
         public void ResetSpellCast()

--- a/src/GameServerLib/GameObjects/Talent.cs
+++ b/src/GameServerLib/GameObjects/Talent.cs
@@ -18,7 +18,7 @@ namespace LeagueSandbox.GameServer.GameObjects
         {
             Name = name;
             Rank = Math.Min(level, GetTalentMaxRank(name));
-            Script = CSharpScriptEngine.CreateObjectStatic<ITalentScript>("Talents", $"Talent_{name}") ?? new EmptyTalentScript();
+            Script = Game.ScriptEngine.CreateObject<ITalentScript>("Talents", $"Talent_{name}") ?? new EmptyTalentScript();
             ScriptNameHash = HashString(name);
         }
     }

--- a/src/GameServerLib/Handlers/CollisionHandler.cs
+++ b/src/GameServerLib/Handlers/CollisionHandler.cs
@@ -5,6 +5,8 @@ using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace LeagueSandbox.GameServer.Handlers
 {
@@ -113,6 +115,15 @@ namespace LeagueSandbox.GameServer.Handlers
             }
 
             return nearest;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float DistanceSquared(Vector2 a, Vector2 b)
+        {
+            float dx = b.X - a.X;
+            float dy = b.Y - a.Y;
+            return dx * dx + dy * dy;
         }
 
         /// <summary>

--- a/src/GameServerLib/Handlers/MapScriptHandler.cs
+++ b/src/GameServerLib/Handlers/MapScriptHandler.cs
@@ -63,7 +63,7 @@ namespace LeagueSandbox.GameServer.Handlers
             Id = _game.Config.GameConfig.Map;
 
             string scriptName = game.Config.GameConfig.GameMode;
-            MapScript = CSharpScriptEngine.CreateObjectStatic<IMapScript>($"MapScripts.Map{Id}", scriptName) ?? new EmptyMapScript();
+            MapScript = Game.ScriptEngine.CreateObject<IMapScript>($"MapScripts.Map{Id}", scriptName) ?? new EmptyMapScript();
             ScriptNameHash = HashString(scriptName);
 
             if (MapScript.PlayerSpawnPoints != null && MapScript.MapScriptMetadata.OverrideSpawnPoints)

--- a/src/GameServerLib/Inventory/Inventory.cs
+++ b/src/GameServerLib/Inventory/Inventory.cs
@@ -80,7 +80,7 @@ namespace LeagueSandbox.GameServer.Inventory
             if (!ItemScripts.ContainsKey(item.ItemId))
             {
                 //Loads the Script
-                ItemScripts.Add(item.ItemId, CSharpScriptEngine.CreateObjectStatic<IItemScript>("ItemPassives", $"ItemID_{item.ItemId}") ?? new ItemScriptEmpty());
+                ItemScripts.Add(item.ItemId, Game.ScriptEngine.CreateObject<IItemScript>("ItemPassives", $"ItemID_{item.ItemId}") ?? new ItemScriptEmpty());
                 try
                 {
                     ItemScripts[item.ItemId].OnActivate(owner);
@@ -244,7 +244,7 @@ namespace LeagueSandbox.GameServer.Inventory
                 if (!ItemScripts.ContainsKey(item.ItemId))
                 {
                     //Loads the Script
-                    ItemScripts.Add(item.ItemId, CSharpScriptEngine.CreateObjectStatic<IItemScript>("ItemPassives", $"ItemID_{item.ItemId}") ?? new ItemScriptEmpty());
+                    ItemScripts.Add(item.ItemId, Game.ScriptEngine.CreateObject<IItemScript>("ItemPassives", $"ItemID_{item.ItemId}") ?? new ItemScriptEmpty());
                     try
                     {
                         ItemScripts[item.ItemId].OnActivate(owner);

--- a/src/GameServerLib/Packets/PacketHandlerManager.cs
+++ b/src/GameServerLib/Packets/PacketHandlerManager.cs
@@ -327,7 +327,7 @@ namespace PacketDefinitions420
             if (data.Length >= 8)
             {
                 // An unhandled exception of type 'System.NullReferenceException' occurred
-                int clientId = ((int)peer.UserData) - 1;
+                int clientId = ((int)peer?.UserData) - 1;
                 data = _blowfishes[clientId].Decrypt(data);
             }
 

--- a/src/GameServerLib/Scripting/AssemblyService.cs
+++ b/src/GameServerLib/Scripting/AssemblyService.cs
@@ -1,0 +1,70 @@
+﻿using LeagueSandbox.GameServer.Logging;
+using LeagueSandbox.GameServer;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace GameServerLib.Scripting;
+
+/// <summary>
+/// Internal class that loads assemblies at server instance creation.
+/// </summary>
+internal static class AssemblyService
+{
+    private static readonly ILog _logger = LoggerProvider.GetLogger();
+    private static readonly List<Assembly> Assemblies = [];
+
+    /// <summary>
+    /// Attempts to load Assembly files that parts of the server will refrence
+    /// </summary>
+    /// <param name="assemblyPaths">Array of paths to assembly DLLs</param>
+    public static void TryLoadAssemblies(string[] assemblyPaths)
+    {
+        CreateAssemblyList(assemblyPaths);
+        Assemblies.Add(ServerLibAssemblyDefiningType.Assembly);
+    }
+
+    /// <returns>An array copy of loaded assemblies</returns>
+    public static Assembly[] GetAssemblies()
+    {
+        return [.. Assemblies];
+    }
+
+    private static void CreateAssemblyList(string[] assemblyPaths)
+    {
+        foreach (var path in assemblyPaths)
+        {
+            string dll;
+            if (!path.EndsWith(".dll"))
+            {
+                dll = path + ".dll";
+            }
+            else
+            {
+                dll = path;
+            }
+
+            if (!File.Exists(dll))
+            {
+                _logger.Error($"Unable to find Assembly {dll}");
+                continue;
+            }
+
+            try
+            {
+                Assembly assembly = Assembly.LoadFile(Path.GetFullPath(dll));
+                Assemblies.Add(assembly);
+            }
+            catch (Exception e)
+            {
+                _logger.Error($"Unable to load assembly: {dll}");
+                _logger.Error(e);
+                continue;
+            }
+
+            _logger.Info($"Successfully loaded assembly: {dll}");
+        }
+    }
+}

--- a/src/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
+++ b/src/GameServerLib/Scripting/CSharp/SpellScriptMetadata.cs
@@ -136,7 +136,7 @@ namespace LeagueSandbox.GameServer.Scripting.CSharp
         /// <summary>
         /// How many times a second the spell sector should check for hitbox collisions.
         /// </summary>
-        public int Tickrate { get; set; } = 0;
+        public float Tickrate { get; set; } = 0f;
         /// <summary>
         /// Whether or not the spell sector should be able to hit something multiple times.
         /// Will only hit again if the unit hit re-enters the hitbox (constant per-collision hitbox).


### PR DESCRIPTION
**Changes proposed:**
- Caster minions (wizard, cannon) doing damage now by missiles. No longer doing nothing.
- Jungle caster minions apply damage now by missiles. (lizards, dragon, baron)
- Target count check in Spell.cs.
- Ashe (E) Passive gold on unit killed.
- Leblanc kit rewrite
- Game Loop is now 30fps (30 executions a second at 33.3ms per frame) sync time is back to 10 seconds
- Fixed Gangplank Q not granting Gold on kill.
- Optimized GetClosestUnitInRange.
- Introduced GetClosestUnitsInRange.
- Aggro range in jungle is reduced, no longer unlimited following / kiting.
- Reduced tickrate by half.
- Katarina Q dealing damage now.
- Packet sanity checks

**Issues addressed:**
https://github.com/AetherionCore/core/issues/12 > This issue should now be fixed, requires a little more play testing to be certain, though 

https://github.com/AetherionCore/core/issues/52


This PR was submitted anonymously; credit is given where it is due. This contribution is greatly appreciated, as it has significantly improved the overall flow of the game.
