### PR TITLE
Private pr

### DIFF
--- a/src/Content/LeagueSandbox-Scripts/AIScripts/BasicJungleMonsterAI.cs
+++ b/src/Content/LeagueSandbox-Scripts/AIScripts/BasicJungleMonsterAI.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.GameObjects;
@@ -26,7 +26,11 @@ namespace AIScripts
             ApiEventManager.OnTakeDamage.AddListener(this, monster, OnTakeDamage, false);
 
             if (monster.Model == "Worm") // disable movement for baron
+            {
+                monster.SetStatus(GameServerCore.Enums.StatusFlags.CanMoveEver, false);
+                monster.SetStatus(GameServerCore.Enums.StatusFlags.Immovable, true);
                 monster.SetStatus(GameServerCore.Enums.StatusFlags.CanMove, false);
+            }
         }
         public void OnTakeDamage(DamageData damageData)
         {

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Annie/Pyromania.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Annie/Pyromania.cs
@@ -1,0 +1,36 @@
+﻿using GameServerCore.Enums;
+using LeagueSandbox.GameServer.GameObjects.StatsNS;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+
+namespace Buffs
+{
+    internal class Pyromania : IBuffGameScript
+    {
+        public BuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.COMBAT_ENCHANCER,
+            BuffAddType = BuffAddType.STACKS_AND_RENEWS,
+            MaxStacks = 4
+        };
+
+        public StatsModifier StatsModifier => new StatsModifier();
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            if (buff.StackCount >= 4)
+            {
+                AddBuff("Pyromania_Particle", 25000f, 1, ownerSpell, unit, unit as ObjAIBase, true);
+                buff.SetStacks(1);
+                NotifyBuffStacks(buff);
+                RemoveBuff(buff);
+            }
+        }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Annie/PyromaniaParticle.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Annie/PyromaniaParticle.cs
@@ -1,0 +1,45 @@
+﻿using GameServerCore.Enums;
+using LeagueSandbox.GameServer.GameObjects.StatsNS;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+
+namespace Buffs
+{
+    internal class Pyromania_Particle : IBuffGameScript
+    {
+        public BuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffAddType = BuffAddType.REPLACE_EXISTING,
+            BuffType = BuffType.COMBAT_ENCHANCER
+        };
+
+        public StatsModifier StatsModifier => new StatsModifier();
+
+        public float StunDuration;
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            var owner = unit;
+            if (owner.Stats.Level >= 1)
+                StunDuration = 1.25f;
+            if (owner.Stats.Level >= 6)
+                StunDuration = 1.5f;
+            if (owner.Stats.Level >= 11)
+                StunDuration = 1.75f;
+
+            LogInfo($"Activating Pyromania_Particle");
+            AddParticleTarget(unit, unit, "StunReady.troy", unit, 25000f, bone: "chest");
+        }
+
+        public void OnDeactivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            RemoveParticleByName(unit.NetId, "StunReady.troy");
+        }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Annie/Pyromania_marker.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Annie/Pyromania_marker.cs
@@ -1,0 +1,33 @@
+﻿using GameServerCore.Enums;
+using LeagueSandbox.GameServer.GameObjects.StatsNS;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+
+namespace Buffs
+{
+
+    internal class Pyromania_Marker : IBuffGameScript
+    {
+        public BuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.AURA,
+            BuffAddType = BuffAddType.RENEW_EXISTING
+        };
+
+        public StatsModifier StatsModifier => new StatsModifier();
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            LogInfo($"Added the marker!");
+        }
+    }
+
+
+
+}

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Global/Slow.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Global/Slow.cs
@@ -41,6 +41,7 @@ namespace Buffs
         public void OnDeactivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
         {
             RemoveParticle(slow);
+            owner.RemoveStatModifier(StatsModifier);
         }
 
         // TODO: Find a better way to transfer data between scripts.

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Items/SightWard.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Items/SightWard.cs
@@ -11,8 +11,6 @@ using GameServerLib.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using System;
 using AIScripts;
-using PacketDefinitions420;
-using GameServerCore;
 
 namespace Buffs
 {
@@ -36,8 +34,7 @@ namespace Buffs
             spell = ownerSpell;
             Unit.Stats.ManaRegeneration.PercentBonus = -1;
             Unit.Stats.CurrentMana = 60f;
-            unit.SetVisibleByTeam(CustomConvert.GetEnemyTeam(unit.Team), false);
-            unit.SetStatus(StatusFlags.Stealthed, true);
+
             ApiEventManager.OnPreTakeDamage.AddListener(this, unit, OnPreTakeDamage, false);
         }
 

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Items/YellowTrinket.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Items/YellowTrinket.cs
@@ -35,7 +35,7 @@ namespace Buffs
             spell = ownerSpell;
             Unit.Stats.ManaRegeneration.PercentBonus = -1;
             Unit.Stats.CurrentMana = 60f;
-            unit.SetStatus(StatusFlags.Stealthed, true);
+
             ApiEventManager.OnPreTakeDamage.AddListener(this, unit, OnPreTakeDamage, false);
         }
 

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Items/YoumuusGhostblade.cs
@@ -1,0 +1,36 @@
+﻿using GameServerCore.Enums;
+using LeagueSandbox.GameServer.GameObjects;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects.StatsNS;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+
+namespace Buffs
+{
+    internal class YoumuusGhostblade : IBuffGameScript
+    {
+        public BuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
+        {
+            BuffType = BuffType.COMBAT_ENCHANCER,
+        };
+
+        public StatsModifier StatsModifier { get; private set; } = new StatsModifier();
+
+        Particle p;
+
+        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            p = AddParticleTarget(ownerSpell.CastInfo.Owner, unit, "spectral_fury_activate_speed", unit, buff.Duration, size: 2);
+            StatsModifier.MoveSpeed.PercentBonus = 0.2f;
+            StatsModifier.AttackSpeed.PercentBonus = 0.4f;
+            unit.AddStatModifier(StatsModifier);
+        }
+
+        public void OnDeactivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
+        {
+            RemoveParticle(p);
+        }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Nasus/NasusQ.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Nasus/NasusQ.cs
@@ -24,9 +24,9 @@ using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 
-namespace NasusQ
+namespace Buffs
 {
-    internal class NasusE : IBuffGameScript
+    internal class NasusQ : IBuffGameScript
     {
         public BuffScriptMetaData BuffMetaData { get; set; } = new BuffScriptMetaData
         {
@@ -51,6 +51,8 @@ namespace NasusQ
                 //pbuff2 = AddParticleTarget(ownerSpell.CastInfo.Owner, ownerSpell.CastInfo.Owner, "Nasus_Base_Q_Wpn_trail.troy", unit, buff.Duration, 1, "BUFFBONE_CSTM_WEAPON_1");
                 StatsModifier.Range.FlatBonus = 50.0f;
                 unit.AddStatModifier(StatsModifier);
+                OverrideAnimation(owner, "Spell1", "Attack1");
+                OverrideAnimation(owner, "Spell1", "Attack2");
                 //SetAnimStates(owner, new Dictionary<string, string> { { "Attack1", "Spell1" } });
                 SealSpellSlot(owner, SpellSlotType.SpellSlots, 0, SpellbookType.SPELLBOOK_CHAMPION, true);
                 ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
@@ -64,10 +66,8 @@ namespace NasusQ
             RemoveParticle(pbuff);
             RemoveParticle(pbuff2);
             RemoveBuff(thisBuff);
-            CreateTimer(0.5f, () =>
-            {
-                //SetAnimStates(owner, new Dictionary<string, string> { { "Spell1", "Attack1" } });
-            });
+            OverrideAnimation(owner, "Attack1", "Spell1");
+            OverrideAnimation(owner, "Attack2", "Spell1");
             if (buff.TimeElapsed >= buff.Duration)
             {
                 ApiEventManager.OnLaunchAttack.RemoveListener(this);
@@ -80,16 +80,15 @@ namespace NasusQ
 
         public void OnLaunchAttack(Spell spell)
         {
-
+            var owner = spell.CastInfo.Owner as Champion;
             if (thisBuff != null && thisBuff.StackCount != 0 && !thisBuff.Elapsed())
             {
                 spell.CastInfo.Owner.RemoveBuff(thisBuff);
-                var owner = spell.CastInfo.Owner as Champion;
                 spell.CastInfo.Owner.SkipNextAutoAttack();
                 SpellCast(spell.CastInfo.Owner, 0, SpellSlotType.ExtraSlots, false, spell.CastInfo.Owner.TargetUnit, Vector2.Zero);
-                SealSpellSlot(owner, SpellSlotType.SpellSlots, 0, SpellbookType.SPELLBOOK_CHAMPION, false);
                 thisBuff.DeactivateBuff();
             }
+            SealSpellSlot(owner, SpellSlotType.SpellSlots, 0, SpellbookType.SPELLBOOK_CHAMPION, false);
         }
         public void OnUpdate(float diff)
         {

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Nasus/NasusQStacks.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Nasus/NasusQStacks.cs
@@ -24,7 +24,7 @@ using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 
-namespace NasusQ
+namespace Buffs
 {
     internal class NasusQStacks : IBuffGameScript
     {
@@ -37,17 +37,12 @@ namespace NasusQ
 
         public StatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
-        Buff thisBuff;
-        ObjAIBase Unit;
-        Particle p;
-        Particle p2;
-        ObjAIBase Owner;
-        AttackableUnit AtOwner;
-        public static float Qstacks = 0f;
 
         public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
         {
             //ApiEventManager.OnKillUnit.AddListener(this, AtOwner, NasusMoreStacks, true);
+            int StackDamage = buff.StackCount;
+            SetSpellToolTipVar(unit, 0, StackDamage, SpellbookType.SPELLBOOK_CHAMPION, 0, SpellSlotType.SpellSlots);
         }
 
         public void OnDeactivate(AttackableUnit unit, Buff buff, Spell ownerSpell)

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Summoners/TeleportBuff.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Summoners/TeleportBuff.cs
@@ -30,9 +30,8 @@ namespace Buffs
             var test = buff.SourceUnit;
             if (test is Minion)
             {
-                unit.SetStatus(StatusFlags.Invulnerable, true);
+                test.SetStatus(StatusFlags.CanMove, false);
                 test.StopMovement();
-                test.CancelAutoAttack(true, true);
             }
             unit.StopMovement();
             unit.SetStatus(StatusFlags.CanMove, false);
@@ -46,7 +45,6 @@ namespace Buffs
             if (test is Minion)
             {
                 test.SetStatus(StatusFlags.CanMove, true);
-                unit.SetStatus(StatusFlags.Invulnerable, false);
                 //test.StopMovement();
             }
             unit.SetStatus(StatusFlags.CanMove, true);

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Volibear/VolibearQ.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Volibear/VolibearQ.cs
@@ -53,6 +53,7 @@ namespace Buffs
         {
             var owner = ownerSpell.CastInfo.Owner as Champion;
             OverrideAnimation(unit, "RUN", "spell1_run");
+            OverrideAnimation(unit, "IDLE1", "spell1_idle");
             RemoveParticle(pbuff);
             RemoveParticle(pbuff2);
             RemoveParticle(pbuff3);

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Volibear/VolibearW.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Volibear/VolibearW.cs
@@ -24,7 +24,6 @@ namespace Buffs
             MaxStacks = 3
         };
 
-        int StackCount;
         public StatsModifier StatsModifier { get; private set; } = new StatsModifier();
 
         public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
@@ -32,7 +31,6 @@ namespace Buffs
             var owner = ownerSpell.CastInfo.Owner;
             StatsModifier.AttackSpeed.PercentBonus = 0.08f;
             unit.AddStatModifier(StatsModifier);
-            StackCount++;
             if (buff.StackCount >= 3)
             {
                 SealSpellSlot(owner, SpellSlotType.SpellSlots, 1, SpellbookType.SPELLBOOK_CHAMPION, false);

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Worm/BaronNashorSpeedBuff.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Worm/BaronNashorSpeedBuff.cs
@@ -31,6 +31,7 @@ namespace Buffs
 
         public void OnDeactivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
         {
+            unit.RemoveStatModifier(StatsModifier);
             RemoveParticle(p1);
             RemoveParticle(p2);
         }

--- a/src/Content/LeagueSandbox-Scripts/Buffs/Worm/ExaltedWithBaronNashor.cs
+++ b/src/Content/LeagueSandbox-Scripts/Buffs/Worm/ExaltedWithBaronNashor.cs
@@ -27,7 +27,7 @@ namespace Buffs
         Buff thisBuff;
         Particle particle;
 
-        public ExaltedWithBaronNashor() {}
+        public ExaltedWithBaronNashor() { }
 
         public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell)
         {
@@ -65,7 +65,7 @@ namespace Buffs
                 if (_game == null)
                 {
                     LogDebug("_game is not initialized in 'ExaltedWithBaronNashor.cs'.");
-                    return; 
+                    return;
                 }
                 else
                 {

--- a/src/Content/LeagueSandbox-Scripts/Characters/Annie/CharScriptAnnie.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Annie/CharScriptAnnie.cs
@@ -1,0 +1,49 @@
+﻿using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.API;
+using GameServerLib.GameObjects.AttackableUnits;
+using Buffs;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects;
+using System;
+
+namespace CharScripts
+{
+    public class CharScriptAnnie : ICharScript
+    {
+        Spell Spell;
+        ObjAIBase unit;
+        public void OnActivate(ObjAIBase owner, Spell spell)
+        {
+            unit = owner;
+            Spell = spell;
+
+            AddBuff("Pyromania Marker", 25000f, 1, spell, unit, unit, false);
+        }
+
+
+        public void OnDeactivate(ObjAIBase owner, Spell spell)
+        {
+            ApiEventManager.OnHitUnit.RemoveListener(this);
+        }
+
+        public void OnUpdate(float diff)
+        {
+            //if (unit != null)
+            //{
+            //    //AddBuff("Pyromania Marker", 250000f, 1, null, unit, unit);
+
+            //    var buffCount = unit.GetBuffWithName("Pyromania")?.StackCount ?? 0;
+            //    LogInfo($"Pyromania Counter {buffCount}");
+            //    if (buffCount >= 4)
+            //    {
+            //        RemoveParticleByName(unit.NetId, "StunReady.troy");
+            //        //AddParticleTarget(unit, unit, "StunReady.troy", unit, 25000f, bone: "chest");
+            //        RemoveBuff(unit, "Pyromania");
+            //    }
+            //}
+        }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Characters/Annie/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Annie/E.cs
@@ -15,13 +15,18 @@ using LeagueSandbox.GameServer.GameObjects.SpellNS;
 
         public void OnSpellPostCast(Spell spell)
         {
-            AddBuff("MoltenShield", 5.0f, 1, spell, spell.CastInfo.Owner, spell.CastInfo.Owner);
-            if (spell.CastInfo.Owner is Champion ch)
+            var owner = spell.CastInfo.Owner;
+            AddBuff("Pyromania", 250000f, 1, spell, owner, owner);
+            var buff = owner.GetBuffWithName("Pyromania");
+            NotifyBuffStacks(buff);
+
+            AddBuff("MoltenShield", 5.0f, 1, spell, owner, owner);
+            if (owner is Champion ch)
             {
                 Pet tibbers = ch.GetPet();
                 if (tibbers != null && !tibbers.IsDead)
                 {
-                    AddBuff("MoltenShield", 5.0f, 1, spell, tibbers, spell.CastInfo.Owner);
+                    AddBuff("MoltenShield", 5.0f, 1, spell, tibbers, owner);
                 }
             }
         }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Annie/Pyromania_Marker.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Annie/Pyromania_Marker.cs
@@ -1,0 +1,27 @@
+﻿using GameServerCore.Enums;
+using LeagueSandbox.GameServer.Scripting.CSharp;
+using LeagueSandbox.GameServer.API;
+using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using GameServerCore.Scripting.CSharp;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
+using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
+
+namespace Spells
+{
+    public class Pyromania_Marker : ISpellScript
+    {
+        public SpellScriptMetadata ScriptMetadata => new SpellScriptMetadata()
+        {
+            TriggersSpellCasts = true,
+            IsDamagingSpell = true
+        };
+
+        public void OnActivate(ObjAIBase owner, Spell spell)
+        {
+
+        }
+    }
+}

--- a/src/Content/LeagueSandbox-Scripts/Characters/Darius/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Darius/BasicAttack.cs
@@ -28,6 +28,7 @@ namespace Spells
             else
             {
                 OverrideAnimation(owner, "Attack1", "Spell2");
+                spell.CastInfo.Owner.SetAutoAttackSpell("DariusBasicAttack", false);
             }
         }
         public void OnLaunchAttack(Spell spell)
@@ -53,6 +54,7 @@ namespace Spells
             else
             {
                 OverrideAnimation(owner, "Attack2", "Spell2");
+                spell.CastInfo.Owner.SetAutoAttackSpell("DariusBasicAttack2", false);
             }
         }
         public void OnLaunchAttack(Spell spell)
@@ -78,6 +80,7 @@ namespace Spells
             else
             {
                 OverrideAnimation(owner, "Crit", "Spell2");
+                spell.CastInfo.Owner.SetAutoAttackSpell("DariusCritAttack", false);
             }
         }
         public void OnLaunchAttack(Spell spell)

--- a/src/Content/LeagueSandbox-Scripts/Characters/Darius/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Darius/Q.cs
@@ -41,7 +41,7 @@ namespace Spells
         public void OnSpellCast(Spell spell)
         {
             PlayAnimation(Darius, "Spell1", 0.5f);
-            AOE.CreateSpellSector(new SectorParameters { Length = 400f, SingleTick = true, Type = SectorType.Area });
+            AOE.CreateSpellSector(new SectorParameters { Length = 450f, SingleTick = true, Type = SectorType.Area });
             AddParticleTarget(Darius, Darius, "darius_Base_Q_aoe_cast.troy", Darius, bone: "C_BuffBone_Glb_Center_Loc");
             AddParticleTarget(Darius, Darius, "darius_Base_Q_aoe_cast_mist.troy", Darius, bone: "C_BuffBone_Glb_Center_Loc");
         }
@@ -56,7 +56,6 @@ namespace Spells
                 if (Math.Abs(Vector2.Distance(target.Position, Darius.Position)) > 200)
                 {
                     target.TakeDamage(Darius, Damage * 1.5f, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
-                    AddBuff("DariusHemo", 5.0f, 1, spell, target, Darius);
                     AddBuff("DariusHemo", 5.0f, 1, spell, target, Darius);
                 }
                 else

--- a/src/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Diana/CharScriptDiana.cs
@@ -2,6 +2,7 @@
 using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
+using LeagueSandbox.GameServer.API;
 
 namespace CharScripts
 {
@@ -13,38 +14,25 @@ namespace CharScripts
         bool beginStance = false;
         bool stance = false;
 
+        Spell Spell;
         public void OnActivate(ObjAIBase owner, Spell spell = null)
         {
-            diana = owner;
+            Spell = spell;
+            {
+                ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
+            }
+            var ownerSkinID = owner.SkinID;
         }
 
-        public void OnUpdate(float diff)
+        public void OnLaunchAttack(Spell spell)
         {
-            if (diana != null)
-            {
-                // Not moving
-                if (diana.CurrentWaypoint == diana.Position && !beginStance)
-                {
-                    PlayAnimation(diana, "Attack1", 5f);
-                    beginStance = true;
-                    if (stillTime >= stanceTime && !stance)
-                    {
-                        beginStance = false;
-                        stance = true;
-                        //PlayAnimation(diana, "Attack1", flags: GameServerCore.Enums.AnimationFlags.Lock);
-                    }
-                    else
-                    {
-                        stillTime += diff;
-                    }
-                }
-                else
-                {
-                    stillTime = 0;
-                    beginStance = false;
-                    stance = false;
-                }
-            }
+            var owner = Spell.CastInfo.Owner;
+            AddBuff("DianaPassive", 4f, 1, Spell, owner, owner);
+        }
+
+        public void OnDeactivate(ObjAIBase owner, Spell spell = null)
+        {
+            ApiEventManager.OnHitUnit.RemoveListener(this);
         }
     }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Gangplank/Q.cs
@@ -18,6 +18,7 @@ namespace Spells
         float Damage;
         ObjAIBase owner;
         SpellMissile Missile;
+        int goldMade = 0;
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
             CastingBreaksStealth = true,
@@ -56,7 +57,11 @@ namespace Spells
                 if (target.IsDead)
                 {
                     if (owner is Champion champ)
+                    {
+                        goldMade += goldIncome;
                         champ.AddGold(target, goldIncome);
+                        SetSpellToolTipVar(owner, 1, goldMade, SpellbookType.SPELLBOOK_CHAMPION, 0, SpellSlotType.SpellSlots);
+                    }
                     var manaCost = new float[] { 50, 55, 60, 65, 70 }[spell.CastInfo.SpellLevel - 1];
                     var newMana = owner.Stats.CurrentMana + manaCost / 2;
                     var maxMana = owner.Stats.ManaPoints.Total;

--- a/src/Content/LeagueSandbox-Scripts/Characters/Global/Recall.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Global/Recall.cs
@@ -56,9 +56,9 @@ namespace Spells
             if (owner.HasBuff("ExaltedWithBaronNashor"))
             {
                 AddBuff("BaronNasahorSpeed", 8f, 1, spell, owner, owner);
-                owner.TakeHeal(owner, owner.Stats.HealthPoints.Total*0.5f, spell);
+                owner.TakeHeal(owner, owner.Stats.HealthPoints.Total * 0.5f, spell);
             }
-            
+
             owner.IconInfo.ResetBorder();
         }
     }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Katarina/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Katarina/E.cs
@@ -11,7 +11,6 @@ using GameServerLib.GameObjects.AttackableUnits;
 using GameServerCore;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
-using LeagueSandbox.GameServer.GameObjects;
 
 namespace Spells
 {
@@ -45,8 +44,7 @@ namespace Spells
             AddParticleTarget(Katarina, null, "katarina_shadowStep_cas.troy", Katarina);
 
             ForceMovement(Katarina, "Spell3", Vector2.Zero, 20, 20, 0.3f, 20);
-            Vector2 behindPos = GetPositionBehind(Target, Katarina, -100f);
-            TeleportTo(Katarina, behindPos.X, behindPos.Y);
+            TeleportTo(Katarina, Target.Position.X, Target.Position.Y);
             AddBuff("KatarinaEReduction", 1.5f, 1, spell, Katarina, Katarina);
             PlayAnimation(Katarina, "Spell3", 0.5f);
         }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Katarina/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Katarina/Q.cs
@@ -30,7 +30,7 @@ namespace Spells
         {
             QMis = spell;
             Katarina = spell.CastInfo.Owner as Champion;
-            Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Target, CanHitSameTarget=false, CanHitSameTargetConsecutively=false });
+            Missile = spell.CreateSpellMissile(new MissileParameters { Type = MissileType.Chained, MaximumHits=4 });
             ApiEventManager.OnSpellMissileHit.AddListener(this, Missile, TargetExecute, false);
         }
         public void TargetExecute(SpellMissile missile, AttackableUnit target)
@@ -41,20 +41,28 @@ namespace Spells
             Damage = 45f + (QMis.CastInfo.SpellLevel * 35f) + (Katarina.Stats.AbilityPower.Total * 0.5f);
             target.TakeDamage(Katarina, Damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
             //AddParticleTarget(owner, target, "katarina_bouncingBlades_tar.troy", target);
-            AddBuff("KatarinaQMark", 4f, 1, QMis, target, Katarina, false);
 
-            var xx = GetClosestUnitsInRange(target, 375, true);
+            var xx = GetClosestUnitsInRange(target, 300, true);
+            var targetsHit = 0;
             foreach (var unit in xx)
             {
                 if (unit.NetId != Katarina.NetId && !unit.IsDead && unit.Team != Katarina.Team
-                    && unit is not BaseTurret && unit.NetId != target.NetId)
+                    && unit is not BaseTurret && unit.NetId != target.NetId 
+                    && !unit.HasBuff("KatarinaQMark"))
                 {
                     LogInfo($"Hitting Second Target {unit.CharData.Name} - {unit.NetId}");
                     SpellCast(Katarina, 2, SpellSlotType.ExtraSlots, false, unit, target.Position);
                     break;
+                    Damage = Damage * 0.9f;
+                    unit.TakeDamage(Katarina, Damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+                    AddBuff("KatarinaQMark", 4f, 1, QMis, unit, Katarina, false);
+                    targetsHit++;
                 }
+                if (targetsHit >= 4)
+                    break;
             }
 
+            AddBuff("KatarinaQMark", 4f, 1, QMis, target, Katarina, false);
         }
 
     }
@@ -72,7 +80,7 @@ namespace Spells
             TriggersSpellCasts = true,
             IsDamagingSpell = true,
             NotSingleTargetSpell = false,
-            PersistsThroughDeath = false,
+            PersistsThroughDeath = true,
             SpellDamageRatio = 1.0f,
         };
 
@@ -93,9 +101,6 @@ namespace Spells
         public void TargetExecute(SpellMissile missile, AttackableUnit target)
         {
             AddBuff("KatarinaQMark", 4f, 1, QMis, target, Katarina, false);
-            Damage = 45f + (QMis.CastInfo.SpellLevel * 35f) + (Katarina.Stats.AbilityPower.Total * 0.5f);
-            target.TakeDamage(Katarina, Damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-            SpellCast(Katarina, 2, SpellSlotType.ExtraSlots, false, missile.TargetUnit, missile.TargetUnit.Position);
         }
     }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Nasus/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Nasus/BasicAttack.cs
@@ -12,36 +12,36 @@ namespace Spells
     {
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            // TODO
+            TriggersSpellCasts = true
         };
 
-        public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
-        {
-            ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
-        }
+        //public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
+        //{
+        //    ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
+        //}
 
-        public void OnLaunchAttack(Spell spell)
-        {
-            spell.CastInfo.Owner.SetAutoAttackSpell("NasusBasicAttack2", false);
-        }
+        //public void OnLaunchAttack(Spell spell)
+        //{
+        //    spell.CastInfo.Owner.SetAutoAttackSpell("NasusBasicAttack2", false);
+        //}
     }
 
     public class NasusBasicAttack2 : ISpellScript
     {
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            // TODO
+            TriggersSpellCasts = true
         };
 
-        public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
-        {
-            ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
-        }
+        //public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
+        //{
+        //    ApiEventManager.OnLaunchAttack.AddListener(this, owner, OnLaunchAttack, false);
+        //}
 
-        public void OnLaunchAttack(Spell spell)
-        {
-            spell.CastInfo.Owner.SetAutoAttackSpell("NasusBasicAttack", false);
-        }
+        //public void OnLaunchAttack(Spell spell)
+        //{
+        //    spell.CastInfo.Owner.SetAutoAttackSpell("NasusBasicAttack", false);
+        //}
     }
 }
 

--- a/src/Content/LeagueSandbox-Scripts/Characters/Nasus/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Nasus/Q.cs
@@ -9,6 +9,7 @@ using GameServerCore.Enums;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
+using LeaguePackets.Game;
 
 namespace Spells
 {
@@ -65,6 +66,7 @@ namespace Spells
     public class NasusQAttack : ISpellScript
     {
         AttackableUnit Target;
+        ObjAIBase Owner;
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
             TriggersSpellCasts = true,
@@ -84,20 +86,26 @@ namespace Spells
         public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
         {
             Target = target;
+            Owner = owner;
         }
         public void OnSpellCast(Spell spell)
         {
             var Owner = spell.CastInfo.Owner;
             if (Owner.HasBuff("NasusQStacks"))
             {
-                float StackDamage = Owner.GetBuffWithName("NasusQStacks").StackCount;
+                int StackDamage = Owner.GetBuffWithName("NasusQStacks").StackCount;
                 float ownerdamage = spell.CastInfo.Owner.Stats.AttackDamage.Total;
                 float damage = 15 + 25 * Owner.GetSpell("NasusQ").CastInfo.SpellLevel + StackDamage + ownerdamage;
                 Target.TakeDamage(Owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_ATTACK, false);
                 AddParticleTarget(Owner, Target, "Nasus_Base_Q_Tar.troy", Target);
                 if (Target.IsDead)
                 {
-                    AddBuff("NasusQStacks", 2500000f, 3, spell, Owner, Owner);
+                    for (int i = 0; i < 3; ++i)
+                        AddBuff("NasusQStacks", 2500000f, 1, spell, Owner, Owner);
+                    //SetSpellToolTipVar<int>(Owner, 1, StackDamage, SpellbookType.SPELLBOOK_CHAMPION, 0, SpellSlotType.SpellSlots);
+                    StackDamage = Owner.GetBuffWithName("NasusQStacks").StackCount;
+                    LogInfo($"StackDamage: {StackDamage}!");
+                    SetBuffToolTipVar(Owner.GetBuffWithName("NasusQStacks"), 0, StackDamage);
                 }
 
             }
@@ -109,12 +117,20 @@ namespace Spells
                 AddParticleTarget(Owner, Target, "Nasus_Base_Q_Tar.troy", Target);
                 if (Target.IsDead)
                 {
-                    AddBuff("NasusQStacks", 2500000f, 3, spell, Owner, Owner);
+                    for (int i = 0; i < 3; ++i)
+                        AddBuff("NasusQStacks", 2500000f, 1, spell, Owner, Owner);
+                    int StackDamage = Owner.GetBuffWithName("NasusQStacks").StackCount;
+                    //SetSpellToolTipVar<int>(Owner, 0, StackDamage, SpellbookType.SPELLBOOK_CHAMPION, 0, SpellSlotType.SpellSlots);
+                    LogInfo($"StackDamage2: {StackDamage}!");
+                    SetBuffToolTipVar(Owner.GetBuffWithName("NasusQStacks"), 0, StackDamage);
                 }
             }
         }
         public void OnSpellPostCast(Spell spell)
         {
+            var Owner = spell.CastInfo.Owner;
+            int StackDamage = Owner.GetBuffWithName("NasusQStacks")?.StackCount ?? 0;
+            //SetSpellToolTipVar(Owner, 1, StackDamage, SpellbookType.SPELLBOOK_CHAMPION, 0, SpellSlotType.SpellSlots);
         }
         public void OnSpellChannel(Spell spell)
         {
@@ -127,6 +143,7 @@ namespace Spells
         }
         public void OnUpdate(float diff)
         {
+
         }
     }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Pantheon/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Pantheon/E.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Missile;
 using LeagueSandbox.GameServer.GameObjects.SpellNS.Sector;
 using LeagueSandbox.GameServer.API;
-using System;
 
 namespace Spells
 {
@@ -30,8 +29,10 @@ namespace Spells
         }
         public SpellSector DamageSector;
 
-        public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
+        public void OnSpellPostCast(Spell spell)
         {
+            var owner = spell.CastInfo.Owner;
+
             var spellPos = new Vector2(spell.CastInfo.TargetPosition.X, spell.CastInfo.TargetPosition.Z);
             FaceDirection(spellPos, owner, false);
             DamageSector = spell.CreateSpellSector(new SectorParameters
@@ -41,10 +42,9 @@ namespace Spells
                 CanHitSameTargetConsecutively = true,
                 OverrideFlags = SpellDataFlags.AffectEnemies | SpellDataFlags.AffectNeutral | SpellDataFlags.AffectMinions | SpellDataFlags.AffectHeroes,
                 Type = SectorType.Cone,
-                Lifetime = 3.0f,
+                Lifetime = 5.0f,
                 ConeAngle = 24.76f,
-            });
-            DamageSector.ExecuteTick();
+            }); 
         }
         public void TargetExecute(Spell spell, AttackableUnit target, SpellMissile missile, SpellSector sector)
         {

--- a/src/Content/LeagueSandbox-Scripts/Characters/Ryze/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Ryze/E.cs
@@ -24,7 +24,6 @@ namespace Spells
         {
             TriggersSpellCasts = true,
             IsDamagingSpell = true,
-            NotSingleTargetSpell=true,
             MissileParameters = new MissileParameters
             {
                 Type = MissileType.Arc

--- a/src/Content/LeagueSandbox-Scripts/Characters/Volibear/E.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Volibear/E.cs
@@ -9,6 +9,8 @@ using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using static LeaguePackets.Game.Common.CastInfo;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
+using Buffs;
 
 namespace Spells
 {
@@ -49,12 +51,13 @@ namespace Spells
 
             foreach (var target in units)
             {
-                if (target is AttackableUnit && spell.CastInfo.Owner != target)
+                if (target is AttackableUnit && (target is not BaseTurret or Inhibitor or Nexus) && spell.CastInfo.Owner != target)
                 {
-                    target.Stats.MoveSpeed.PercentBonus = -slow;
-                    target.TakeDamage(spell.CastInfo.Owner, damage, GameServerCore.Enums.DamageType.DAMAGE_TYPE_MAGICAL, GameServerCore.Enums.DamageSource.DAMAGE_SOURCE_SPELL, false);
+                    var buff = (IBuffGameScript)AddBuff("Slow", 3.0f, 1, spell, target, spell.CastInfo.Owner) as Slow;
+                    buff.SetSlowMod(slow);
+                    target.TakeDamage(spell.CastInfo.Owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
 
-                    CreateTimer(3.0f, () => { target.Stats.MoveSpeed.PercentBonus = 0f; });
+                    //CreateTimer(3.0f, () => { target.Stats.MoveSpeed.PercentBonus = 0f; });
                 }
             }
         }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Volibear/Passive.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Volibear/Passive.cs
@@ -14,19 +14,41 @@ namespace CharScripts
     {
         ObjAIBase Owner;
         float timer = 0;
+
         public void OnActivate(ObjAIBase owner, Spell spell)
         {
             Owner = owner;
+
+            //if (owner.HasBuff("VolibearQ"))
+            //{
+            //    PlayAnimation(owner, "spell1_idle");
+            //}
+            //else
+            //{
+            //    StopAnimation(owner, "spell1_idle");
+            //}
         }
 
         public void OnUpdate(float diff)
         {
-            timer -= diff;
-            if (Owner.Stats.CurrentHealth <= Owner.Stats.HealthPoints.Total * 0.3f && timer <= 0)
+            try
             {
-                AddBuff("VolibearPassiveBuff", 6f, 1, null, Owner, Owner, false);
-                timer = 120000f;
+                timer -= diff;
+                if (Owner.Stats.CurrentHealth <= Owner.Stats.HealthPoints.Total * 0.3f && timer <= 0)
+                {
+                    AddBuff("VolibearPassiveBuff", 6f, 1, null, Owner, Owner, false);
+                    timer = 120000f;
+                }
             }
+            catch
+            {
+
+            }
+        }
+
+        public void OnDeactivate(ObjAIBase owner, Spell spell)
+        {
+            ApiEventManager.OnHitUnit.RemoveListener(this);
         }
     }
 }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Volibear/Q.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Volibear/Q.cs
@@ -6,8 +6,10 @@ using LeagueSandbox.GameServer.API;
 using LeagueSandbox.GameServer.Content;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
+using LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.AnimatedBuildings;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.Scripting.CSharp;
+using System;
 using System.Numerics;
 using static LeagueSandbox.GameServer.API.ApiFunctionManager;
 
@@ -31,8 +33,9 @@ namespace Spells
         {
             if (VolibearQAttack.Applied == 0)
             {
+                LogInfo($"Applying Spell Now!");
                 spell.CastInfo.Owner.PlayAnimation("Spell2", 0.5f, flags: AnimationFlags.Override);
-                CreateTimer(0.5f, () => { spell.CastInfo.Owner.StopAnimation("Spell1", fade: true); });
+                //CreateTimer(0.5f, () => { spell.CastInfo.Owner.StopAnimation("Spell1", fade: true); });
             }
         }
 
@@ -40,16 +43,17 @@ namespace Spells
         {
         }
 
-        public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
+        /*public void OnSpellPreCast(ObjAIBase owner, Spell spell, AttackableUnit target, Vector2 start, Vector2 end)
         {
-            //var owner = spell.CastInfo.Owner as IChampion;
-            // ??
-            AddBuff("VoliQBuffSwag", 6.0f, 1, spell, owner, owner);
-
-        }
+            AddBuff("VolibearQ", 6.0f, 1, spell, owner, owner);
+        }*/
 
         public void OnSpellCast(Spell spell)
         {
+            var owner = spell.CastInfo.Owner;
+            PlayAnimation(owner, "Spell1", 0.5f);
+            owner.CancelAutoAttack(true);
+            AddBuff("VolibearQ", 4.0f, 1, spell, owner, owner);
         }
 
         public void OnSpellPostCast(Spell spell)
@@ -77,9 +81,9 @@ namespace Spells
     {
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {
-            TriggersSpellCasts = false,
-            NotSingleTargetSpell = true
-            // TODO
+            TriggersSpellCasts = true,
+            NotSingleTargetSpell = true,
+            IsDamagingSpell = true,
         };
 
         private Spell originspell;
@@ -96,17 +100,25 @@ namespace Spells
         public void TargetExecute(DamageData data)
         {
             var owner = ownermain;
+            //owner.PlayAnimation("Spell2", 0.5f, flags: AnimationFlags.Override);
 
             var ADratio = owner.Stats.AttackDamage.PercentBonus * 0.3f;
             var damage = 40f + (30f * (originspell.CastInfo.SpellLevel - 1)) + ADratio;
             if (Applied != 1)
             {
                 var unit = originspell.CastInfo.Targets[0].Unit;
-                var x = GetPointFromUnit(owner, -200);
-                unit.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
-                var xy = unit as ObjAIBase;
-                xy.SetTargetUnit(null);
-                ForceMovement(unit, "Spell1", x, 500, 0, 20, 0);
+                if (!(unit is BaseTurret or Inhibitor or Nexus))
+                {
+                    unit.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_SPELL, false);
+
+                    if (!unit.Status.HasFlag(StatusFlags.Immovable))
+                    {
+                        var x = GetPointFromUnit(owner, -200);
+                        ForceMovement(unit, "Spell1", x, 500, 0, 20, 0, movementOrdersType: ForceMovementOrdersType.CANCEL_ORDER);
+                        var xy = unit as ObjAIBase;
+                        xy.SetTargetUnit(null);
+                    }
+                }
                 Applied = 1;
                 //CreateTimer((float)6, () => { Applied = 1; });
             }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Volibear/W.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Volibear/W.cs
@@ -24,23 +24,30 @@ namespace Spells
 
         public void OnActivate(ObjAIBase owner, Spell spell)
         {
+            own = owner;
             Spell = spell;
             ApiEventManager.OnHitUnit.AddListener(this, owner, TargetExecute, false);
             ApiEventManager.OnLevelUpSpell.AddListener(this, spell, HideW, false);
-            own = owner;
         }
 
         private int hit = 0;
 
         public void TargetExecute(DamageData data)
         {
+            if (data.Attacker is Champion champ && champ.Spells[1].CastInfo.SpellLevel <= 0)
+                return;
+
             var owner = Spell.CastInfo.Owner;
             AddBuff("VolibearW", 4f, 1, Spell, owner, owner, false);
         }
 
         public void HideW(Spell spell)
         {
-            CreateTimer((float)0.1, () => { SealSpellSlot(own, SpellSlotType.SpellSlots, 1, SpellbookType.SPELLBOOK_CHAMPION, true); });
+            if ((own.GetBuffWithName("VolibearW")?.StackCount ?? 0) < 3)
+            {
+                LogInfo($"Disabling W NOW!");
+                SealSpellSlot(own, SpellSlotType.SpellSlots, 1, SpellbookType.SPELLBOOK_CHAMPION, true);
+            }
         }
 
         public void OnDeactivate(ObjAIBase owner, Spell spell)
@@ -54,10 +61,9 @@ namespace Spells
         public void OnSpellCast(Spell spell)
         {
             var ap = own.Stats.HealthPoints.FlatBonus * 0.15f;
-            LogDebug("HP: " + ap.ToString());
             float damage = (float)(ap + 35 + (own.Spells[1].CastInfo.SpellLevel * 45));
             spell.CastInfo.Targets[0].Unit.TakeDamage(own, damage, DamageType.DAMAGE_TYPE_PHYSICAL, DamageSource.DAMAGE_SOURCE_PROC, false);
-            SealSpellSlot(own, SpellSlotType.SpellSlots, 1, SpellbookType.SPELLBOOK_CHAMPION, true);
+            SealSpellSlot(own, SpellSlotType.SpellSlots, 1, SpellbookType.SPELLBOOK_CHAMPION, spell.CastInfo.Owner.CanCast(spell));
             hit = 0;
             //SealSpellSlot(spell.CastInfo.Owner, SpellSlotType.SpellSlots, 2, SpellbookType.SPELLBOOK_CHAMPION, true);
         }

--- a/src/Content/LeagueSandbox-Scripts/Characters/Worm/BasicAttack.cs
+++ b/src/Content/LeagueSandbox-Scripts/Characters/Worm/BasicAttack.cs
@@ -1,27 +1,13 @@
-﻿using GameServerCore.Scripting.CSharp;
+using GameServerCore.Scripting.CSharp;
 using LeagueSandbox.GameServer.GameObjects.AttackableUnits;
 using LeagueSandbox.GameServer.GameObjects.SpellNS;
 using LeagueSandbox.GameServer.GameObjects;
 using LeagueSandbox.GameServer.Scripting.CSharp;
 using GameServerCore.Enums;
-using LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI;
-using System.Numerics;
-using LeagueSandbox.GameServer.Handlers;
 
 namespace Spells
 {
     public class WormBasicAttack : ISpellScript
-    {
-        public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
-        {
-            TriggersSpellCasts = true,
-            IsDamagingSpell = true,
-            MissileParameters = new MissileParameters { Type = MissileType.Target }
-        };
-        public void OnActivate(AttackableUnit unit, Buff buff, Spell ownerSpell) { }
-    }
-
-    public class WormAttack : ISpellScript
     {
         public SpellScriptMetadata ScriptMetadata { get; private set; } = new SpellScriptMetadata()
         {

--- a/src/GameServerLib/API/ApiEventManager.cs
+++ b/src/GameServerLib/API/ApiEventManager.cs
@@ -143,6 +143,8 @@ namespace LeagueSandbox.GameServer.API
                 = new Dispatcher<AttackableUnit>();
         public static Dispatcher<Spell> OnLevelUpSpell
                 = new Dispatcher<Spell>();
+        public static Dispatcher<Spell> OnPreLevelUpSpell
+                = new Dispatcher<Spell>();
         public static Dispatcher<AttackableUnit> OnMoveEnd
                 = new Dispatcher<AttackableUnit>();
         public static Dispatcher<AttackableUnit> OnMoveFailure

--- a/src/GameServerLib/API/ApiFunctionManager.cs
+++ b/src/GameServerLib/API/ApiFunctionManager.cs
@@ -312,6 +312,11 @@ namespace LeagueSandbox.GameServer.API
             return buff;
         }
 
+        public static void NotifyBuffStacks(Buff buff)
+        {
+            _game.PacketNotifier.NotifyNPC_BuffUpdateCount(buff, buff.Duration, buff.TimeElapsed);
+        }
+
         /// <summary>
         /// Whether or not the specified unit has the specified buff instance.
         /// </summary>
@@ -1306,6 +1311,11 @@ namespace LeagueSandbox.GameServer.API
                 if ((spell?.SpellName?.Contains(itemSpellName) ?? false))
                     spell.SetCooldown(spell.GetCooldown(), true);
             }
+        }
+
+        public static void RemoveParticleByName(uint netId, string particleName)
+        {
+            _game.ObjectManager.RemoveParticleByName(netId, particleName);
         }
     }
 }

--- a/src/GameServerLib/Chatbox/Commands/HelpCommand.cs
+++ b/src/GameServerLib/Chatbox/Commands/HelpCommand.cs
@@ -24,7 +24,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
             var lastCommandString = "";
             var isNewMessage = false;
 
-            ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "List of available commands: ");
+            ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "List of available commands: ", userId);
 
             foreach (var command in commands)
             {

--- a/src/GameServerLib/Chatbox/Commands/ReviveCommand.cs
+++ b/src/GameServerLib/Chatbox/Commands/ReviveCommand.cs
@@ -18,7 +18,7 @@ namespace LeagueSandbox.GameServer.Chatbox.Commands
         public override void Execute(int userId, bool hasReceivedArguments, string arguments = "")
         {
             var champ = _playerManager.GetPeerInfo(userId).Champion;
-            if (!champ.IsDead)
+            if (!champ.IsDead && string.IsNullOrEmpty(arguments))
             {
                 ChatCommandManager.SendDebugMsgFormatted(DebugMsgType.INFO, "Your champion is already alive.", userId);
                 return;

--- a/src/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AI/BaseTurret.cs
@@ -54,6 +54,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             ParentObject = mapObject;
             SetTeam(team);
             Replication = new ReplicationAITurret(this);
+
+            SetStatus(StatusFlags.CanMove, false);
+            SetStatus(StatusFlags.CanMoveEver, false);
         }
 
 

--- a/src/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AI/Champion.cs
@@ -300,6 +300,21 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             IsDead = false;
             RespawnTimer = -1;
             SetDashingState(false, MoveStopReason.HeroReincarnate);
+            SetStatus(StatusFlags.CanAttack, true);
+            SetStatus(StatusFlags.CanCast, true);
+            SetStatus(StatusFlags.CanMove, true);
+            SetStatus(StatusFlags.Stunned, false);
+            SetStatus(StatusFlags.Rooted, false);
+            SetStatus(StatusFlags.Disarmed, false);
+            SetStatus(StatusFlags.Rooted, false);
+            SetStatus(StatusFlags.Suppressed, false);
+
+            Stats.SetActionState(ActionState.CAN_ATTACK, true);
+            Stats.SetActionState(ActionState.CAN_CAST, true);
+            Stats.SetActionState(ActionState.CAN_MOVE, true);
+
+            SetStatus(StatusFlags.CanMove, true);
+            SetStatus(StatusFlags.Rooted, false);
             ApiEventManager.OnResurrect.Publish(this);
         }
 

--- a/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AI/ObjAIBase.cs
@@ -749,7 +749,6 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             }
 
             s.LevelUp();
-            ApiEventManager.OnLevelUpSpell.Publish(s);
             return s;
         }
 
@@ -1069,7 +1068,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.AI
             base.Update(diff);
             try
             {
-                CharScript.OnUpdate(diff);
+                CharScript?.OnUpdate(diff);
             }
             catch (Exception e)
             {

--- a/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -1552,6 +1552,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         /// TODO: Implement Dash class which houses these parameters, then have that as the only parameter to this function (and other Dash-based functions).
         public void DashToLocation(Vector2 endPos, float dashSpeed, string animation = "", float leapGravity = 0.0f, bool keepFacingLastDirection = true, bool consideredCC = true)
         {
+            if (Status.HasFlag(StatusFlags.Immovable))
+                return;
+
             var newCoords = _game.Map.NavigationGrid.GetClosestTerrainExit(endPos, PathfindingRadius + 1.0f);
 
             // False because we don't want this to be networked as a normal movement.

--- a/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/AttackableUnit.cs
@@ -327,7 +327,7 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
             {
                 _game.PacketNotifier.NotifyS2C_SetFadeOut(this, 0f, 1.5f, userId);
             }
-            if(Status.HasFlag(StatusFlags.Stealthed) && IsVisibleByTeam(team))
+            if (Status.HasFlag(StatusFlags.Stealthed) && IsVisibleByTeam(team))
             {
                 _game.PacketNotifier.NotifyS2C_SetFadeOut(this, 0.3f, 1.5f, userId);
             }
@@ -487,6 +487,11 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits
         public virtual void TakeHeal(AttackableUnit caster, float amount, IEventSource sourceScript = null)
         {
             Stats.CurrentHealth = Math.Clamp(Stats.CurrentHealth + amount, 0, Stats.HealthPoints.Total);
+        }
+
+        public virtual void TakeMana(AttackableUnit caster, float amount, IEventSource sourceScript = null)
+        {
+            Stats.CurrentMana = Math.Clamp(Stats.CurrentMana + amount, 0, Stats.ManaPoints.Total);
         }
 
         /// <summary>

--- a/src/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Inhibitor.cs
@@ -29,6 +29,9 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
         {
             InhibitorState = DampenerState.RespawningState;
             Lane = laneId;
+
+            SetStatus(StatusFlags.CanMove, false);
+            SetStatus(StatusFlags.CanMoveEver, false);
         }
 
         public override void OnAdded()

--- a/src/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
+++ b/src/GameServerLib/GameObjects/AttackableUnits/Buildings/AnimatedBuildings/Nexus.cs
@@ -17,6 +17,8 @@ namespace LeagueSandbox.GameServer.GameObjects.AttackableUnits.Buildings.Animate
             uint netId = 0
         ) : base(game, model, collisionRadius, position, visionRadius, netId, team, stats)
         {
+            SetStatus(StatusFlags.CanMove, false);
+            SetStatus(StatusFlags.CanMoveEver, false);
         }
 
         public override void SetToRemove()

--- a/src/GameServerLib/Packets/PacketHandlers/HandleUpgradeSpell.cs
+++ b/src/GameServerLib/Packets/PacketHandlers/HandleUpgradeSpell.cs
@@ -1,6 +1,7 @@
 ﻿using GameServerCore.Packets.PacketDefinitions.Requests;
 using GameServerCore.Packets.Handlers;
 using LeagueSandbox.GameServer.Players;
+using LeagueSandbox.GameServer.API;
 
 namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 {
@@ -29,7 +30,7 @@ namespace LeagueSandbox.GameServer.Packets.PacketHandlers
 
             _game.PacketNotifier.NotifyNPC_UpgradeSpellAns(userId, champion.NetId, req.Slot, s.CastInfo.SpellLevel, champion.SkillPoints);
             champion.Stats.SetSpellEnabled(req.Slot, true);
-
+            ApiEventManager.OnLevelUpSpell.Publish(s);
             return true;
         }
     }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixed Gangplank's Q Gold counter
- Fixed OnLevelUpSpell to fire after the response to client
- Modified ReviveCommand to help unstuck
- Turrets & Inhibs & Nexus & Baron will no longer be able to move/flipped
- Fixed all annie spells, added stun, added passive indicator, fixed tibbers damage not triggering on spawn
- Fixed Nasus Q, added stacks, stacks indicators and more.
- Fixed Volibear stacking attack speed without having W
- Fixed volibear flipping everything
- Added new methods to the API
- Added Particle removal by netid & name for convenience

**Issues addressed:**

Closes:
https://github.com/AetherionCore/core/issues/16

**Tests performed:**

Requires some more Volibear testing


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 